### PR TITLE
新增 dockerfile 以利於在 Ubuntu 22.04 上建立 NuOJ-Sandbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:22.04
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+# setup mirror
+RUN sed 's@archive.ubuntu.com@free.nchc.org.tw@' -i /etc/apt/sources.list
+# apt update
+RUN apt-get update
+RUN apt-get install -y python3 python3-pip git build-essential libcap-dev
+# set env
+ENV PYTHONUNBUFFERED=0
+# mkdir
+RUN rm -rf /etc/nuoj-sandbox
+RUN mkdir /etc/nuoj-sandbox
+RUN mkdir /etc/nuoj-sandbox/storage
+RUN mkdir /etc/nuoj-sandbox/storage/testcase
+RUN mkdir /etc/nuoj-sandbox/storage/submission
+RUN mkdir /etc/nuoj-sandbox/storage/result
+RUN mkdir /etc/isolate
+# make isolate
+RUN git clone https://github.com/ioi/isolate.git /etc/isolate
+WORKDIR /etc/isolate
+RUN make isolate
+RUN make install
+# cd to nuoj-sandbox
+WORKDIR /etc/nuoj-sandbox
+COPY . /etc/nuoj-sandbox/
+# install pyhton package from pip
+RUN pip3 install Flask
+RUN pip3 install requests
+# expose port with 4439
+EXPOSE 4439
+# execute command
+CMD python3 sandbox_be.py


### PR DESCRIPTION
 - 在這次的更動，新增了一個 `dockerfile` ，可在 docker 上安裝 `NuOJ-Sandbox` 的環境。
 
建立指令：`docker build -t nuoj-sandbox . --no-cache`
運行指令：`docker run -P -e PYTHONUNBUFFERED=1 --privileged nuoj-sandbox`