### PR TITLE
修復 Golang 測試假成功的問題

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 RUN sed 's@archive.ubuntu.com@free.nchc.org.tw@' -i /etc/apt/sources.list
 # apt update
 RUN apt-get update
-RUN apt-get install -y python3 python3-pip git build-essential libcap-dev
+RUN apt-get install -y python3 python3-pip git build-essential libcap-dev golang
 # set env
 ENV PYTHONUNBUFFERED=0
 # mkdir


### PR DESCRIPTION
 - Golang 在 #19 的測試顯示成功，但是是假成功，實際上在 production 版本是無法運行的。
 - 在 Docker 上新增 Golang 的安裝。
 - 微調了 Sandbox 的存取，將其可以存取 Golang 的檔案，才能夠讓 Golang 進行編譯。