### PR TITLE
修復 `dockerfile` 無法開啟應用程式的問題

### DIFF
--- a/.github/workflows/docker_workflow.yml
+++ b/.github/workflows/docker_workflow.yml
@@ -18,4 +18,4 @@ jobs:
 
     - name: Stop containers
       if: always()
-      run: docker compose up down
+      run: docker compose down -v

--- a/.github/workflows/docker_workflow.yml
+++ b/.github/workflows/docker_workflow.yml
@@ -3,7 +3,7 @@ on: push
 jobs:
   docker:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/docker_workflow.yml
+++ b/.github/workflows/docker_workflow.yml
@@ -10,7 +10,7 @@ jobs:
 
     - name: Check Control Group
       run: |
-        cd /sys/fs/cgroup
+        cd /sys/fs/cgroup/memory
         ls
 
     - name: Start containers

--- a/.github/workflows/docker_workflow.yml
+++ b/.github/workflows/docker_workflow.yml
@@ -3,7 +3,7 @@ on: push
 jobs:
   docker:
     timeout-minutes: 10
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/docker_workflow.yml
+++ b/.github/workflows/docker_workflow.yml
@@ -8,6 +8,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: Check Control Group
+      run: |
+        cd /sys/fs/cgroup
+        ls
+
     - name: Start containers
       run: docker compose up --build --exit-code-from "sandbox-test" sandbox-test
 

--- a/.github/workflows/docker_workflow.yml
+++ b/.github/workflows/docker_workflow.yml
@@ -9,8 +9,8 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Start containers
-      run: docker-compose -f "docker-compose.yml" up --build --exit-code-from "sandbox-test" sandbox-test
+      run: docker compose up --build --exit-code-from "sandbox-test" sandbox-test
 
     - name: Stop containers
       if: always()
-      run: docker-compose -f "docker-compose.yml" down
+      run: docker compose up down

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,5 @@ RUN pip3 install pytest
 # expose port with 4439
 EXPOSE 4439
 # execute command
-CMD python3 sandbox_be.py
+WORKDIR /etc/nuoj-sandbox/backend
+CMD flask --debug run --host 0.0.0.0 --port 4439

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3.8"
 
 services:
   sandbox:


### PR DESCRIPTION
## What's the problem?

在這份 PR 中，我們嘗試修復 `dockerfile` 無法開啟應用程式的問題。

問題主要來自於使用了應用工廠，但開啟的方式不是應用工廠的開啟方式。

同時連帶修好了 Github Action 在測試方面找不到 `/sys/fs/cgroup/memory` 的問題。