### PR TITLE
讓 `docker` 使用 `requirements.txt` 來安裝套件

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,7 @@ RUN make install
 WORKDIR /etc/nuoj-sandbox
 COPY . /etc/nuoj-sandbox/
 # install pyhton package from pip
-RUN pip3 install Flask
-RUN pip3 install requests
-RUN pip3 install dataclass_wizard
-RUN pip3 install pytest
+RUN pip3 install -r requirements.txt
 # expose port with 4439
 EXPOSE 4439
 # execute command


### PR DESCRIPTION
## What's new?

在這份 PR 中，我們讓 `docker` 使用 `requirements.txt` 來安裝 `pip` 套件，取代逐行使用指令建置來降低效率。