### PR TITLE
創立 `SettingBuilder` 物件以適用各種情況的設定

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -12,12 +12,16 @@ from api.swagger.route import swagger_api_bp
 from api.system.route import system_api_bp
 from api.test_case.route import test_case_api_bp
 from api.judge.sandbox_util import execute_queueing_task_when_exist_empty_box
+from setting.util import Setting, SettingBuilder
 
 from flask import Flask
 
 
 def create_app(config_filename=None) -> Flask:
     app = Flask(__name__)
+    
+    app.config["setting"] = SettingBuilder().from_file("setting.json")
+    
     app.register_blueprint(judge_api_bp)
     app.register_blueprint(result_api_bp)
     app.register_blueprint(swagger_api_bp)

--- a/backend/setting.json
+++ b/backend/setting.json
@@ -1,4 +1,3 @@
 {
-    "port": 4439,
     "sandbox_number": 5
 }

--- a/backend/setting/util.py
+++ b/backend/setting/util.py
@@ -1,0 +1,17 @@
+import json
+from dataclasses import dataclass
+
+@dataclass
+class Setting:
+    sandbox_number: int
+    
+
+class SettingBuilder:
+    def from_file(self, file_path: str) -> Setting:
+        with open(file_path) as f:
+            raw_setting_text: str = f.read()
+            setting_dict: dict[str, str] = json.loads(raw_setting_text)
+            return self.from_mapping(setting_dict)
+            
+    def from_mapping(self, mapping: dict[str, str]) -> Setting:
+        return Setting(**mapping)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from app import create_app
-
+from setting.util import Setting, SettingBuilder
 
 @pytest.fixture()
 def app():
@@ -11,6 +11,9 @@ def app():
             "TESTING": True,
         }
     )
+    
+    with app.app_context():
+        app.config["setting"] = SettingBuilder().from_mapping({"sandbox_number": 1})
 
     # other setup can go here
 


### PR DESCRIPTION
## What's new?

在這份 PR 中，我們創立了 `SettingBuilder` 與 `Setting`，透過 Simple Factory 的方式來造出 `Setting` 物件，這樣就能交由 `app.config` 來暫存設定，並讓測試環境與運行環境的設定檔是獨立的。