### PR TITLE
新增 `app` 的設定方式與去除儲存庫的絕對路徑

### DIFF
--- a/backend/api/judge/route.py
+++ b/backend/api/judge/route.py
@@ -1,7 +1,8 @@
 import json
 import uuid
 
-from flask import Blueprint, Response, request
+from flask import Blueprint, Response, current_app, request
+
 from api.judge.sandbox_util import (
     execute_task_with_specific_tracker_id,
     submission_list,
@@ -29,7 +30,8 @@ def judge_route():
             status=400,
         )
 
-    open("/etc/nuoj-sandbox/storage/submission/%s.json" % tracker_id, "w").write(
+    storage_path: str = current_app.config["STORAGE_PATH"]
+    open(f"{storage_path}/submission/{tracker_id}.json", "w").write(
         json.dumps(data)
     )
     del data

--- a/backend/api/judge/sandbox_util.py
+++ b/backend/api/judge/sandbox_util.py
@@ -17,6 +17,7 @@ from api.judge.sandbox_enum import (
 import requests
 from dataclass_wizard import JSONWizard
 from datetime import datetime
+from flask import current_app
 
 
 setting = json.loads(open("./setting.json", "r").read())
@@ -73,7 +74,8 @@ def execute_queueing_task_when_exist_empty_box():
 
 def fetch_test_case_from_storage(filename: str) -> list[str]:
     json_object: list[str]
-    with open(f"/etc/nuoj-sandbox/storage/testcase/{filename}.json", "r") as f:
+    storage_path: str = current_app.config["STORAGE_PATH"]
+    with open(f"{storage_path}/testcase/{filename}.json", "r") as f:
         json_object = json.loads(f.read())
     return json_object
 
@@ -146,7 +148,8 @@ def finish_task(task: Task):
 
 
 def dump_task_result_to_storage(task: Task, tracker_id: int):
-    path = f"/etc/nuoj-sandbox/storage/result/{tracker_id}.result"
+    storage_path: str = current_app.config["STORAGE_PATH"]
+    path = f"{storage_path}/result/{tracker_id}.result"
 
     with open(path, "w") as f:
         f.write(json.dumps(task.result, indent=4))
@@ -154,7 +157,8 @@ def dump_task_result_to_storage(task: Task, tracker_id: int):
 
 def fetch_json_object_from_storage(tracker_id: int) -> dict[str, Any]:
     raw_json_object: str
-    with open("/etc/nuoj-sandbox/storage/submission/%s.json" % tracker_id, "r") as f:
+    storage_path: str = current_app.config["STORAGE_PATH"]
+    with open(f"{storage_path}/submission/{tracker_id}.json") as f:
         raw_json_object = f.read()
     return json.loads(raw_json_object)
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -17,9 +17,14 @@ from setting.util import Setting, SettingBuilder
 from flask import Flask
 
 
-def create_app(config_filename=None) -> Flask:
+def create_app(config_mapping: dict[str, str] = None) -> Flask:
     app = Flask(__name__)
     
+    if config_mapping is not None:
+        app.config.from_mapping(config_mapping)
+    else:
+        app.config.from_pyfile("config.py")
+        
     app.config["setting"] = SettingBuilder().from_file("setting.json")
     
     app.register_blueprint(judge_api_bp)

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,1 @@
+STORAGE_PATH="/etc/nuoj-sandbox/storage"

--- a/backend/storage/util.py
+++ b/backend/storage/util.py
@@ -1,14 +1,17 @@
 import os
 from storage.tunnel_code import TunnelCode
 
+from flask import current_app
 
 def file_storage_tunnel_exist(filename: str, tunnel: TunnelCode) -> bool:
-    path = "/etc/nuoj-sandbox/storage/%s/%s" % (tunnel.value, filename)
+    storage_path: str = current_app.config["STORAGE_PATH"]
+    path = f"{storage_path}/{tunnel.value}/{filename}"
     return os.path.exists(path)
 
 
 def file_storage_tunnel_read(filename: str, tunnel: TunnelCode) -> str:
-    path = "/etc/nuoj-sandbox/storage/%s/%s" % (tunnel.value, filename)
+    storage_path: str = current_app.config["STORAGE_PATH"]
+    path = f"{storage_path}/{tunnel.value}/{filename}"
     if file_storage_tunnel_exist(filename, tunnel):
         with open(path, "r") as file:
             return file.read()
@@ -17,7 +20,8 @@ def file_storage_tunnel_read(filename: str, tunnel: TunnelCode) -> str:
 
 
 def byte_storage_tunnel_read(filename: str, tunnel: TunnelCode) -> bytes:
-    path = "/etc/nuoj-sandbox/storage/%s/%s" % (tunnel.value, filename)
+    storage_path: str = current_app.config["STORAGE_PATH"]
+    path = f"{storage_path}/{tunnel.value}/{filename}"
     if file_storage_tunnel_exist(filename, tunnel):
         with open(path, "rb") as file:
             return file.read()
@@ -26,21 +30,24 @@ def byte_storage_tunnel_read(filename: str, tunnel: TunnelCode) -> bytes:
 
 
 def file_storage_tunnel_write(filename: str, data: str, tunnel: TunnelCode) -> None:
-    path = "/etc/nuoj-sandbox/storage/%s/%s" % (tunnel.value, filename)
+    storage_path: str = current_app.config["STORAGE_PATH"]
+    path = f"{storage_path}/{tunnel.value}/{filename}"
     with open(path, "w") as file:
         file.write(data)
         file.close()
 
 
 def byte_storage_tunnel_write(filename: str, data, tunnel: TunnelCode) -> None:
-    path = "/etc/nuoj-sandbox/storage/%s/%s" % (tunnel.value, filename)
+    storage_path: str = current_app.config["STORAGE_PATH"]
+    path = f"{storage_path}/{tunnel.value}/{filename}"
     with open(path, "wb") as file:
         file.write(data)
         file.close()
 
 
 def file_storage_tunnel_del(filename: str, tunnel: TunnelCode) -> str:
-    path = "/etc/nuoj-sandbox/storage/%s/%s" % (tunnel.value, filename)
+    storage_path: str = current_app.config["STORAGE_PATH"]
+    path = f"{storage_path}/{tunnel.value}/{filename}"
     if file_storage_tunnel_exist(filename, tunnel):
         os.remove(path)
     else:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,27 +1,37 @@
 import pytest
+from tempfile import mkdtemp
+from pathlib import Path
+from shutil import rmtree
 
 from app import create_app
 from setting.util import Setting, SettingBuilder
 
 @pytest.fixture()
 def app():
-    app = create_app()
-    app.config.update(
+    storage_path: str = mkdtemp()
+    app = create_app(
         {
-            "TESTING": True,
+            "STORAGE_PATH": storage_path
         }
     )
     
     with app.app_context():
         app.config["setting"] = SettingBuilder().from_mapping({"sandbox_number": 1})
-
+        _create_storage_folder(storage_path)
+        
     # other setup can go here
 
     yield app
 
     # clean up / reset resources here
+    rmtree(storage_path)
 
 
 @pytest.fixture()
 def client(app):
     return app.test_client()
+
+def _create_storage_folder(storage_path: str):
+    (Path(storage_path) / "result").mkdir()
+    (Path(storage_path) / "submission").mkdir()
+    (Path(storage_path) / "testcase").mkdir()

--- a/backend/tests/test.py
+++ b/backend/tests/test.py
@@ -36,7 +36,7 @@ class TestJudge:
             "checker_code": open(
                 "/etc/nuoj-sandbox/example_code/checker.cpp", "r"
             ).read(),
-            "test_case": [{"use": "static-file", "file": "testcase"}],
+            "test_case": [{"use": "plain-text", "text": "4 1 2 3 4"}],
             "execute_type": "J",
             "user_language": "cpp",
             "solution_language": "cpp",
@@ -59,7 +59,7 @@ class TestJudge:
             "checker_code": open(
                 "/etc/nuoj-sandbox/example_code/checker.cpp", "r"
             ).read(),
-            "test_case": [{"use": "static-file", "file": "testcase"}],
+            "test_case": [{"use": "plain-text", "text": "4 1"}],
             "execute_type": "J",
             "user_language": "py",
             "solution_language": "py",


### PR DESCRIPTION
## What's new?

在這份 PR 中，我們新增了能夠使用檔案或者使用 `dictionary` 的方式來設定 `app` 的設定，並且將儲存庫（Storage）的路徑改為由 設定定義的路徑，可用來讓運行環境與測試環境的儲存庫路徑是不同的。