### PR TITLE
修改 `nuoj-sandbox-test` 在 Pytest 的目標資料夾

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,4 +17,4 @@ services:
       - sandbox
     working_dir: /etc/nuoj-sandbox/backend
     command:
-      python3 -m pytest --no-header -vv ./tests/test.py
+      python3 -m pytest --no-header -vv ./tests/ --cov


### PR DESCRIPTION
## What's new

在這份 PR 中，我們修改了 `nuoj-sandbox-test` 在 `Pytest` 的目標資料夾，從原先設定只測試 `test.py`，到測試整個 `/tests` 資料夾內所有的測試。

## Why the test failed?

因為沒有測試，手動測試後證實可用。