### PR TITLE
新增 `.coveragerc` 來定義 `Pytest` 的相關參數

### DIFF
--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+branch = True
+omit = tests/**/*.py
+
+[report]
+show_missing = True
+exclude_lines =
+  # Re-enable the standard pragma
+  pragma: no cover
+
+  # Type checking only
+  if TYPE_CHECKING:


### PR DESCRIPTION
## What's new?

在這份 PR 中，我們新增了 `.coveragerc` 來定義 `Pytest` 的相關參數，定義測試資料夾、忽略資料夾與報告相關設定