### PR TITLE
新增 `memory` 參數至執行階段與評測階段

### DIFF
--- a/backend/tests/api/judge/test_route.py
+++ b/backend/tests/api/judge/test_route.py
@@ -35,6 +35,7 @@ def payload(user_code: str, checker_code: str) -> dict[str, Any]:
         "execute_type": "Judge",
         "options": {
             "threading": False,
+            "memory": 131072,
             "time": 4,
             "wall_time": 4
         }

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -101,6 +101,7 @@ def test_task(checker_code: str, user_code: str):
         execute_type=ExecuteType.JUDGE.value,
         options=Option(
             threading=False,
+            memory=131072,
             time=2.5,
             wall_time=2.5,
         ),

--- a/backend/tests/utils/isolate/test_util.py
+++ b/backend/tests/utils/isolate/test_util.py
@@ -55,7 +55,7 @@ def box_environment():
         ("cg_mem", 4096, "--cg-mem=4096 "),
         ("cg_timing", 15, "--cg-timing=15 "),
         ("dir", ("random_file", "rw"), "--dir=random_file:rw "),
-        ("mem", 131072, "--mem=131072 ")
+        ("mem", 131072, "--mem=131072 "),
     ]
 )
 def test_generate_options_with_parameter_should_generate_correct_command(args_key, args_value, excepted_command):

--- a/backend/tests/utils/isolate/test_util.py
+++ b/backend/tests/utils/isolate/test_util.py
@@ -55,6 +55,7 @@ def box_environment():
         ("cg_mem", 4096, "--cg-mem=4096 "),
         ("cg_timing", 15, "--cg-timing=15 "),
         ("dir", ("random_file", "rw"), "--dir=random_file:rw "),
+        ("mem", 131072, "--mem=131072 ")
     ]
 )
 def test_generate_options_with_parameter_should_generate_correct_command(args_key, args_value, excepted_command):
@@ -168,7 +169,7 @@ def test_execute_should_execute_the_program(box_environment: None, user_code: st
         file.write("5")
     subprocess.call("isolate --box-id=0 --open-files=2048 --full-env --processes --cg  --run -- /usr/bin/g++ submit_code.cpp -o submit_code.o", shell=True)
         
-    meta = execute(CodeType.SUBMIT.value, 0, 5, 5, Language.CPP.value, 0)
+    meta = execute(CodeType.SUBMIT.value, 0, 5, 5, 131072, Language.CPP.value, 0)
     
     assert "exitcode:0" in meta
     with open("/var/local/lib/isolate/0/box/1.out") as file:
@@ -182,7 +183,7 @@ def test_execute_with_submit_code_should_generate_output_file(box_environment: N
         file.write("5")
     subprocess.call("isolate --box-id=0 --open-files=2048 --full-env --processes --cg  --run -- /usr/bin/g++ submit_code.cpp -o submit_code.o", shell=True)
         
-    execute(CodeType.SUBMIT.value, 0, 5, 5, Language.CPP.value, 0)
+    execute(CodeType.SUBMIT.value, 0, 5, 5, 131072, Language.CPP.value, 0)
     
     assert Path("/var/local/lib/isolate/0/box/1.out").exists()
 
@@ -194,7 +195,7 @@ def test_execute_with_submit_code_should_generate_meta_file(box_environment: Non
         file.write("5")
     subprocess.call("isolate --box-id=0 --open-files=2048 --full-env --processes --cg  --run -- /usr/bin/g++ submit_code.cpp -o submit_code.o", shell=True)
         
-    execute(CodeType.SUBMIT.value, 0, 5, 5, Language.CPP.value, 0)
+    execute(CodeType.SUBMIT.value, 0, 5, 5, 131072, Language.CPP.value, 0)
     
     assert Path("/var/local/lib/isolate/0/box/1.out.mt").exists()
 
@@ -206,7 +207,7 @@ def test_execute_with_solution_should_generate_answer_file(box_environment: None
         file.write("5")
     subprocess.call("isolate --box-id=0 --open-files=2048 --full-env --processes --cg  --run -- /usr/bin/g++ solution.cpp -o solution.o", shell=True)
         
-    execute(CodeType.SOLUTION.value, 0, 5, 5, Language.CPP.value, 0)
+    execute(CodeType.SOLUTION.value, 0, 5, 5, 131072, Language.CPP.value, 0)
     
     assert Path("/var/local/lib/isolate/0/box/1.ans").exists()
 
@@ -218,7 +219,7 @@ def test_execute_with_solution_should_generate_meta_file(box_environment: None, 
         file.write("5")
     subprocess.call("isolate --box-id=0 --open-files=2048 --full-env --processes --cg  --run -- /usr/bin/g++ solution.cpp -o solution.o", shell=True)
         
-    execute(CodeType.SOLUTION.value, 0, 5, 5, Language.CPP.value, 0)
+    execute(CodeType.SOLUTION.value, 0, 5, 5, 131072, Language.CPP.value, 0)
     
     assert Path("/var/local/lib/isolate/0/box/1.ans.mt").exists()
 

--- a/backend/utils/isolate/util.py
+++ b/backend/utils/isolate/util.py
@@ -83,7 +83,7 @@ def generate_isolate_run_command(
     stderr: str | None = None,
     meta: str | None = None,
     dir: tuple[str, str] | None = None,
-    memory: int | None = None,
+    mem: int | None = None,
 ) -> str:
     # --box-id=%d --time=%d --wall-time=%d --cg-mem 256000 -p --full-env --meta='%s' --stdin='%d.in' --stdout='%s' --meta='%s'
     options = generate_options_with_parameter(
@@ -99,7 +99,7 @@ def generate_isolate_run_command(
         open_files=2048,
         cg=True,
         dir=dir,
-        memory=memory
+        mem=mem
     )
     return f"isolate {options} --run -- {execute_command}"
 

--- a/backend/utils/isolate/util.py
+++ b/backend/utils/isolate/util.py
@@ -29,7 +29,7 @@ def generate_options_with_parameter(
     cg_mem: int | None = None,
     cg_timing: int | None = None,
     dir: tuple[str, str] = None,
-    memory: int | None = None
+    mem: int | None = None
 ) -> str:
     values_options_map = {
         "--time": time,
@@ -45,7 +45,7 @@ def generate_options_with_parameter(
         "--cg-mem": cg_mem,
         "--cg-timing": cg_timing,
         "--meta": meta,
-        "--mem": memory
+        "--mem": mem
     }
     boolean_options_map = {
         "--stderr-to-stdout": stderr_to_stdout,
@@ -309,7 +309,7 @@ def execute(type, test_case_index, time, wall_time, memory, language, box_id=0) 
     input_file = f"{test_case_index+1}.in"
     output_file = f"{test_case_index+1}.{extension}"
     command = generate_isolate_run_command(
-        exec_command, box_id, wall_time, time, input_file, output_file, meta=meta_path, memory=memory
+        exec_command, box_id, wall_time, time, input_file, output_file, meta=meta_path, mem=memory
     )
     touch_text_file_by_file_name("init", output_file, box_id)
     
@@ -344,7 +344,7 @@ def checker(test_case_index, time, wall_time, box_id):
     answer_name = f"{test_case_index+1}.ans"
     execute_command = f"{code_output} {input_name} {output_name} {answer_name}"
     command = generate_isolate_run_command(
-        execute_command, box_id, wall_time=wall_time, time=time, meta=meta_path, stderr=checker_msg_file_name, memory=131072
+        execute_command, box_id, wall_time=wall_time, time=time, meta=meta_path, stderr=checker_msg_file_name, mem=131072
     )
     
     subprocess.call(command, shell=True)

--- a/backend/utils/isolate/util.py
+++ b/backend/utils/isolate/util.py
@@ -344,7 +344,7 @@ def checker(test_case_index, time, wall_time, box_id):
     answer_name = f"{test_case_index+1}.ans"
     execute_command = f"{code_output} {input_name} {output_name} {answer_name}"
     command = generate_isolate_run_command(
-        execute_command, box_id, wall_time=wall_time, time=time, meta=meta_path, stderr=checker_msg_file_name
+        execute_command, box_id, wall_time=wall_time, time=time, meta=meta_path, stderr=checker_msg_file_name, memory=131072
     )
     
     subprocess.call(command, shell=True)

--- a/backend/utils/isolate/util.py
+++ b/backend/utils/isolate/util.py
@@ -29,6 +29,7 @@ def generate_options_with_parameter(
     cg_mem: int | None = None,
     cg_timing: int | None = None,
     dir: tuple[str, str] = None,
+    memory: int | None = None
 ) -> str:
     values_options_map = {
         "--time": time,
@@ -44,6 +45,7 @@ def generate_options_with_parameter(
         "--cg-mem": cg_mem,
         "--cg-timing": cg_timing,
         "--meta": meta,
+        "--mem": memory
     }
     boolean_options_map = {
         "--stderr-to-stdout": stderr_to_stdout,
@@ -80,7 +82,8 @@ def generate_isolate_run_command(
     stdout: str | None = None,
     stderr: str | None = None,
     meta: str | None = None,
-    dir: tuple[str, str] | None = None
+    dir: tuple[str, str] | None = None,
+    memory: int | None = None,
 ) -> str:
     # --box-id=%d --time=%d --wall-time=%d --cg-mem 256000 -p --full-env --meta='%s' --stdin='%d.in' --stdout='%s' --meta='%s'
     options = generate_options_with_parameter(
@@ -96,6 +99,7 @@ def generate_isolate_run_command(
         open_files=2048,
         cg=True,
         dir=dir,
+        memory=memory
     )
     return f"isolate {options} --run -- {execute_command}"
 
@@ -281,7 +285,7 @@ def compile(type, language, box_id=0) -> str:
     return read_meta(box_id, name=meta_name)
 
 
-def execute(type, test_case_index, time, wall_time, language, box_id=0) -> str:
+def execute(type, test_case_index, time, wall_time, memory, language, box_id=0) -> str:
     """
     Execute the program on the specific ID of the sandbox.
 
@@ -305,7 +309,7 @@ def execute(type, test_case_index, time, wall_time, language, box_id=0) -> str:
     input_file = f"{test_case_index+1}.in"
     output_file = f"{test_case_index+1}.{extension}"
     command = generate_isolate_run_command(
-        exec_command, box_id, wall_time, time, input_file, output_file, meta=meta_path
+        exec_command, box_id, wall_time, time, input_file, output_file, meta=meta_path, memory=memory
     )
     touch_text_file_by_file_name("init", output_file, box_id)
     

--- a/backend/utils/sandbox/function/util.py
+++ b/backend/utils/sandbox/function/util.py
@@ -21,7 +21,8 @@ def execute_code(type: CodeType, compiler: str, option: Option, testcase_index: 
     """
     time = option.time
     wall_time = option.wall_time
-    meta = execute(type.value, testcase_index, time, wall_time, compiler, box_id)
+    memory = option.memory
+    meta = execute(type.value, testcase_index, time, wall_time, memory, compiler, box_id)
     meta_data = meta_data_to_dict(meta)
     return meta_data
     

--- a/backend/utils/sandbox/util.py
+++ b/backend/utils/sandbox/util.py
@@ -20,6 +20,7 @@ class Option:
     threading: bool
     time: float
     wall_time: float
+    memory: int
     webhook_url: str | None = None
 
 @dataclass


### PR DESCRIPTION
## What's new?

在這份 PR 中，我們嘗試新增了 `memory` 參數至執行階段，在執行階段時限制程式的記憶體用量。
在評測階段，由於大多情況我們並不需要可變的控制使用者的 checker 執行用量，因此我們設置為 `131072 KB`（`128 MB`）

