### PR TITLE
完成 `webhook_url` 相關的測試

### DIFF
--- a/backend/api/judge/util.py
+++ b/backend/api/judge/util.py
@@ -101,11 +101,7 @@ def _send_webhook_with_webhook_url(task: Task, tracker_id: int):
         if resp.status_code != 200:
             print(f"webhook_url {task.options.webhook_url} has error that occur result {tracker_id} has error.")
         else:
-            json_data = json.loads(resp.text)
-            if json_data["status"] != "OK":
-                print(f"webhook_url {task.options.webhook_url} has error that occur result {tracker_id} send failed.")
-            else:
-                print(f"webhook_url {task.options.webhook_url} send successfully.")
+            print(f"webhook_url {task.options.webhook_url} send successfully.")
 
 class FlaskThread(threading.Thread):
     def __init__(self, *args, **kwargs) -> None:

--- a/backend/api/test/route.py
+++ b/backend/api/test/route.py
@@ -1,0 +1,21 @@
+from http import HTTPStatus
+from typing import Any
+
+from flask import Blueprint, make_response, request
+
+test_bp = Blueprint("test", __name__, url_prefix="/api/test")
+
+# The test route for testing webhook when judge methods completed.
+# Since it is just a test route, we assert json is not None and status filed exists.
+# The status field will determine what status code should return. 
+# When the verdict is AC it should return OK code and status OK in payload, otherwise, it should return status Forbidden code and failed message.
+@test_bp.route("/webhook", methods=["POST"])
+def test_webhooks():
+    json: dict[str, Any] | None = request.get_json(silent=True)
+    assert json is not None
+    assert "status" in json
+    
+    if json["data"]["status"] == "AC":
+        return make_response({"status": "OK"}, HTTPStatus.OK)
+    else:
+        return make_response({"message": "Failed"}, HTTPStatus.FORBIDDEN)

--- a/backend/app.py
+++ b/backend/app.py
@@ -11,6 +11,7 @@ from api.judge.route import judge_api_bp
 from api.judge.util import execute_queueing_task_when_exist_empty_box
 from api.result.route import result_api_bp
 from api.system.route import system_api_bp
+from api.test.route import test_bp
 from api.test_case.route import test_case_api_bp
 from setting.util import Setting, SettingBuilder
 
@@ -35,6 +36,7 @@ def create_app(config_mapping: dict[str, str] = None) -> Flask:
     app.register_blueprint(judge_api_bp)
     app.register_blueprint(result_api_bp)
     app.register_blueprint(system_api_bp)
+    app.register_blueprint(test_bp)
     app.register_blueprint(test_case_api_bp)
 
     pop_work_timer = FlaskThread(app, target=execute_queueing_task_when_exist_empty_box)

--- a/backend/tests/api/judge/test_route.py
+++ b/backend/tests/api/judge/test_route.py
@@ -60,7 +60,7 @@ def test_submit_code_with_threading_should_respond_http_status_code_ok(client: F
     assert result_response.json["result"]["judge_detail"][0]["verdict"] == "AC"    
 
 def test_submit_ok_status_report_with_webhooks_parameter_should_print_successfully_message(client: FlaskClient, payload: dict[str, Any], capfd: Generator[pytest.CaptureFixture[str], None, None]):
-    payload["options"]["webhook_url"] = "http://localhost:4439/api/test/webhook"
+    payload["options"]["webhook_url"] = "http://sandbox:4439/api/test/webhook"
     
     response: TestResponse = client.post("/api/judge", json=payload)
     
@@ -70,7 +70,7 @@ def test_submit_ok_status_report_with_webhooks_parameter_should_print_successful
     assert "send successfully" in out.split("\n")[-2]
 
 def test_submit_ce_status_report_with_webhooks_parameter_should_print_failed_message(client: FlaskClient, payload: dict[str, Any], capfd: Generator[pytest.CaptureFixture[str], None, None]):
-    payload["options"]["webhook_url"] = "http://localhost:4439/api/test/webhook"
+    payload["options"]["webhook_url"] = "http://sandbox:4439/api/test/webhook"
     payload["user_code"]["code"] = ""
     
     response: TestResponse = client.post("/api/judge", json=payload)

--- a/backend/tests/api/judge/test_route.py
+++ b/backend/tests/api/judge/test_route.py
@@ -1,7 +1,7 @@
 import json
 from http import HTTPStatus
 from time import sleep
-from typing import Any
+from typing import Any, Generator
 
 import pytest
 from flask.testing import FlaskClient
@@ -58,6 +58,27 @@ def test_submit_code_with_threading_should_respond_http_status_code_ok(client: F
     _wait_status_finished(client, tracker_id)
     result_response: TestResponse= client.get(f"/api/result/{tracker_id}/")
     assert result_response.json["result"]["judge_detail"][0]["verdict"] == "AC"    
+
+def test_submit_ok_status_report_with_webhooks_parameter_should_print_successfully_message(client: FlaskClient, payload: dict[str, Any], capfd: Generator[pytest.CaptureFixture[str], None, None]):
+    payload["options"]["webhook_url"] = "http://localhost:4439/api/test/webhook"
+    
+    response: TestResponse = client.post("/api/judge", json=payload)
+    
+    assert response.status_code == HTTPStatus.OK
+    assert response.json["result"]["judge_detail"][0]["verdict"] == "AC"  
+    out, _ = capfd.readouterr()
+    assert "send successfully" in out.split("\n")[-2]
+
+def test_submit_ce_status_report_with_webhooks_parameter_should_print_failed_message(client: FlaskClient, payload: dict[str, Any], capfd: Generator[pytest.CaptureFixture[str], None, None]):
+    payload["options"]["webhook_url"] = "http://localhost:4439/api/test/webhook"
+    payload["user_code"]["code"] = ""
+    
+    response: TestResponse = client.post("/api/judge", json=payload)
+    
+    assert response.status_code == HTTPStatus.OK
+    assert response.json["result"]["compile_detail"]["submit"]["exitcode"] == "1"  
+    out, _ = capfd.readouterr()
+    assert "has error that occur result" in out.split("\n")[-2]
 
 
 def _wait_status_finished(client: FlaskClient, tracker_id: str):


### PR DESCRIPTION
## What's new?

在這份 PR 中，我們新增了 `webhook_url` 測試相關的參數，並新增了一個測試接口 `/api/test/webook` 用於在單元測試中測試。

透過新增了兩個測試來測試傳送 webhooks 後，不同的狀態所對應的輸出，將測試覆蓋比率提升至了 `95%`。