### PR TITLE
修復預設 setting.json 中對於 `g++` 與 `gcc` 路徑位置錯誤所引發的錯誤

### DIFF
--- a/backend/setting.json
+++ b/backend/setting.json
@@ -16,7 +16,7 @@
                     "dist": "checker.o"
                 }
             },
-            "compile": "/bin/g++ --std=c++14 {source} -o {dist}",
+            "compile": "/usr/bin/g++ --std=c++14 {source} -o {dist}",
             "execute": "./{dist}",
             "setting": {
                 "wall_time_limit": 3,
@@ -38,7 +38,7 @@
                     "dist": "checker.o"
                 }
             },
-            "compile": "/bin/gcc --std=c11 {source} -o {dist}",
+            "compile": "/usr/bin/gcc --std=c11 {source} -o {dist}",
             "execute": "./{dist}",
             "setting": {
                 "wall_time_limit": 3,


### PR DESCRIPTION
## What's new?

在這份 PR 中，我們修復了預設 `setting.json` 中對於 `g++` 與 `gcc` 路徑錯誤所引發的錯誤。