### PR TITLE
讓 `docker-compose` 能夠讀取使用者的環境變數

### DIFF
--- a/.github/workflows/docker_workflow_disable_cg.yml
+++ b/.github/workflows/docker_workflow_disable_cg.yml
@@ -3,25 +3,12 @@ on: push
 jobs:
   docker:
     timeout-minutes: 10
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       NUOJ_SANDBOX_ENABLE_CG: 0
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-
-    - name: Check Control Group
-      run: |
-        cd /sys/fs/cgroup/memory
-        ls
-    
-    - name: Disable SWAP ASLR THS
-      run: |
-        sudo swapoff -a
-        echo "0" | sudo tee /proc/sys/kernel/randomize_va_space
-        sudo echo "never" | sudo tee /sys/kernel/mm/transparent_hugepage/enabled
-        sudo echo "never" | sudo tee /sys/kernel/mm/transparent_hugepage/defrag
-        sudo echo "0" | sudo tee /sys/kernel/mm/transparent_hugepage/khugepaged/defrag
     
     - name: Check config
       run: docker compose config

--- a/.github/workflows/docker_workflow_disable_cg.yml
+++ b/.github/workflows/docker_workflow_disable_cg.yml
@@ -1,0 +1,32 @@
+name: Docker Compose Actions Workflow
+on: push
+jobs:
+  docker:
+    timeout-minutes: 10
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Check Control Group
+      run: |
+        cd /sys/fs/cgroup/memory
+        ls
+    
+    - name: Disable SWAP ASLR THS
+      run: |
+        sudo swapoff -a
+        echo "0" | sudo tee /proc/sys/kernel/randomize_va_space
+        sudo echo "never" | sudo tee /sys/kernel/mm/transparent_hugepage/enabled
+        sudo echo "never" | sudo tee /sys/kernel/mm/transparent_hugepage/defrag
+        sudo echo "0" | sudo tee /sys/kernel/mm/transparent_hugepage/khugepaged/defrag
+    
+    - name: Disable NUOJ_SANDBOX_ENABLE_CG
+      run: export NUOJ_SANDBOX_ENABLE_CG=0
+
+    - name: Start containers
+      run: docker compose up --build --exit-code-from "sandbox-test" sandbox-test
+
+    - name: Stop containers
+      if: always()
+      run: docker compose down -v

--- a/.github/workflows/docker_workflow_disable_cg.yml
+++ b/.github/workflows/docker_workflow_disable_cg.yml
@@ -1,9 +1,11 @@
-name: Docker Compose Actions Workflow
+name: Docker CI [Disable CG]
 on: push
 jobs:
   docker:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
+    env:
+      NUOJ_SANDBOX_ENABLE_CG: 0
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -21,8 +23,8 @@ jobs:
         sudo echo "never" | sudo tee /sys/kernel/mm/transparent_hugepage/defrag
         sudo echo "0" | sudo tee /sys/kernel/mm/transparent_hugepage/khugepaged/defrag
     
-    - name: Disable NUOJ_SANDBOX_ENABLE_CG
-      run: export NUOJ_SANDBOX_ENABLE_CG=0
+    - name: Check config
+      run: docker compose config
 
     - name: Start containers
       run: docker compose up --build --exit-code-from "sandbox-test" sandbox-test

--- a/.github/workflows/docker_workflow_enable_cg.yml
+++ b/.github/workflows/docker_workflow_enable_cg.yml
@@ -1,9 +1,11 @@
-name: Docker Compose Actions Workflow
+name: Docker CI [Enable CG]
 on: push
 jobs:
   docker:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
+    env:
+      NUOJ_SANDBOX_ENABLE_CG: 1
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -21,8 +23,8 @@ jobs:
         sudo echo "never" | sudo tee /sys/kernel/mm/transparent_hugepage/defrag
         sudo echo "0" | sudo tee /sys/kernel/mm/transparent_hugepage/khugepaged/defrag
     
-    - name: Enable NUOJ_SANDBOX_ENABLE_CG
-      run: export NUOJ_SANDBOX_ENABLE_CG=1
+    - name: Check config
+      run: docker compose config
 
     - name: Start containers
       run: docker compose up --build --exit-code-from "sandbox-test" sandbox-test

--- a/.github/workflows/docker_workflow_enable_cg.yml
+++ b/.github/workflows/docker_workflow_enable_cg.yml
@@ -21,6 +21,9 @@ jobs:
         sudo echo "never" | sudo tee /sys/kernel/mm/transparent_hugepage/defrag
         sudo echo "0" | sudo tee /sys/kernel/mm/transparent_hugepage/khugepaged/defrag
     
+    - name: Enable NUOJ_SANDBOX_ENABLE_CG
+      run: export NUOJ_SANDBOX_ENABLE_CG=1
+
     - name: Start containers
       run: docker compose up --build --exit-code-from "sandbox-test" sandbox-test
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: "3.8"
 services:
   sandbox:
     build: .
+    environment:
+      - NUOJ_SANDBOX_ENABLE_CG=${NUOJ_SANDBOX_ENABLE_CG}
     tty: true
     privileged: true
     restart: always
@@ -12,10 +14,11 @@ services:
     build: .
     environment:
       - PYTHONUNBUFFERED=1
-      - NUOJ_SANDBOX_ENABLE_CG=1
+      - NUOJ_SANDBOX_ENABLE_CG=${NUOJ_SANDBOX_ENABLE_CG}
     privileged: true
     depends_on:
       - sandbox
     working_dir: /etc/nuoj-sandbox/backend
     command:
       python3 -m pytest --no-header -vv ./tests/ --cov
+  


### PR DESCRIPTION
## What's new

在這個 PR 中，我們在 `docker-compose` 中讀取使用者設置的環境變數，使用者在 `export NUOJ_SANDBOX_ENABLE_CG=<value>` 後，在 `docker-compose` 中會去讀取這個環境變數，並識別使用者意圖想要開啟 `CG` 或不開啟 `CG`。

我們額外創了一個 `Docker CI [Disable CG]` 的 workflow，並將原先的 workflow 更改為 `Docker CI [Enable CG]`，用於在持續整合的情況下能夠確定開啟與不開啟都能夠正常運作。