### PR TITLE
連接 MinIO 服務

### DIFF
--- a/.github/workflows/docker_workflow_disable_cg.yml
+++ b/.github/workflows/docker_workflow_disable_cg.yml
@@ -14,7 +14,7 @@ jobs:
       run: docker compose config
 
     - name: Start containers
-      run: docker compose up --build --exit-code-from "sandbox-test" sandbox-test
+      run: docker compose up --build --exit-code-from "sandbox-test" minio-test sandbox-test
 
     - name: Stop containers
       if: always()

--- a/.github/workflows/docker_workflow_enable_cg.yml
+++ b/.github/workflows/docker_workflow_enable_cg.yml
@@ -27,7 +27,9 @@ jobs:
       run: docker compose config
 
     - name: Start containers
-      run: docker compose up --build --exit-code-from "sandbox-test" sandbox-test
+      run: |
+        docker compose up --build minio-test
+        docker compose up --build --exit-code-from "sandbox-test" sandbox-test
 
     - name: Stop containers
       if: always()

--- a/.github/workflows/docker_workflow_enable_cg.yml
+++ b/.github/workflows/docker_workflow_enable_cg.yml
@@ -27,9 +27,7 @@ jobs:
       run: docker compose config
 
     - name: Start containers
-      run: |
-        docker compose up --build minio-test
-        docker compose up --build --exit-code-from "sandbox-test" sandbox-test
+      run: docker compose up --build --exit-code-from "sandbox-test" minio-test sandbox-test
 
     - name: Stop containers
       if: always()

--- a/backend/app.py
+++ b/backend/app.py
@@ -61,13 +61,14 @@ def _initialize_minio_storage_server(setting: Setting):
     access_key: str = environ.get("MINIO_ACCESS_KEY", "")
     secret_key: str = environ.get("MINIO_SECRET_KEY", "")
 
-    client: Minio = Minio(setting.minio.endpoint, access_key=access_key, secret_key=secret_key)
+    client: Minio = Minio(setting.minio.endpoint, access_key=access_key, secret_key=secret_key, secure=False)
 
     try:
         client.bucket_exists("notexistbucket")
         logger.info("MinIO connect successfully.")
         return client
     except:
+        logger.error(traceback.format_exc())
         logger.error("MinIO connect failed.")
         return None
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -17,6 +17,8 @@ from api.test_case.route import test_case_api_bp
 from setting.util import Setting, SettingBuilder
 
 from flask import Flask, current_app
+from loguru import logger
+from minio import Minio
 
 
 def create_app(config_mapping: dict[str, str] = None) -> Flask:
@@ -35,6 +37,7 @@ def create_app(config_mapping: dict[str, str] = None) -> Flask:
     app.config["result_mapping"] = {}
     app.config["semaphores"] = Semaphore(setting.sandbox_number)
     app.config["control_group"] = enable_cg
+    app.config["minio_client"] = _initialize_minio_storage_server(setting)
     
     app.register_blueprint(judge_api_bp)
     app.register_blueprint(result_api_bp)
@@ -47,6 +50,26 @@ def create_app(config_mapping: dict[str, str] = None) -> Flask:
     pop_work_timer.start()
 
     return app
+
+
+def _initialize_minio_storage_server(setting: Setting):
+    
+    if setting.minio.enable == False:
+        logger.info("Disable MinIO storage server, skip the initialization.")
+        return None
+    
+    access_key: str = environ.get("MINIO_ACCESS_KEY", "")
+    secret_key: str = environ.get("MINIO_SECRET_KEY", "")
+
+    client: Minio = Minio(setting.minio.endpoint, access_key=access_key, secret_key=secret_key)
+
+    try:
+        client.bucket_exists("notexistbucket")
+        logger.info("MinIO connect successfully.")
+        return client
+    except:
+        logger.error("MinIO connect failed.")
+        return None
 
 
 class FlaskThread(threading.Thread):

--- a/backend/setting.json
+++ b/backend/setting.json
@@ -47,7 +47,7 @@
         }
     },
     "minio": {
-        "enable": false,
-        "endpoint": "minio:9090"
+        "enable": true,
+        "endpoint": "minio:9000"
     }
 }

--- a/backend/setting.json
+++ b/backend/setting.json
@@ -45,5 +45,9 @@
                 "memory_limit": 131072
             }
         }
+    },
+    "minio": {
+        "enable": true,
+        "endpoint": "minio:9090"
     }
 }

--- a/backend/setting.json
+++ b/backend/setting.json
@@ -47,7 +47,7 @@
         }
     },
     "minio": {
-        "enable": true,
+        "enable": false,
         "endpoint": "minio:9090"
     }
 }

--- a/backend/setting/util.py
+++ b/backend/setting/util.py
@@ -42,10 +42,18 @@ class CompilerSetting:
         command = command.replace("{dist}", self.file_name[type]["dist"])
         return command
 
+
+@dataclass
+class MinIOConfig:
+    enable: bool
+    endpoint: str
+
+
 @dataclass
 class Setting:
     sandbox_number: int
     compiler: dict[str, CompilerSetting]
+    minio: MinIOConfig
 
 
 class SettingBuilder:
@@ -58,7 +66,8 @@ class SettingBuilder:
     def from_mapping(self, mapping: dict[str, str]) -> Setting:
         return Setting(
             sandbox_number=mapping["sandbox_number"],
-            compiler=convert_compiler_dict_to_compiler_setting_object(mapping["compiler"])
+            compiler=convert_compiler_dict_to_compiler_setting_object(mapping["compiler"]),
+            minio=MinIOConfig(**mapping["minio"])
         )
 
 

--- a/backend/storage/minio_util.py
+++ b/backend/storage/minio_util.py
@@ -1,0 +1,23 @@
+from os import environ
+from typing import Final
+
+from minio import Minio
+from flask import current_app
+
+from setting.util import Setting
+
+
+def heartbeat() -> bool:
+    setting: Setting = current_app.config["setting"]
+    
+    ACCESS_KEY: Final[str] = environ.get("MINIO_ACCESS_KEY")
+    SECRET_KEY: Final[str] = environ.get("MINIO_SECRET_KEY")
+    ENDPOINT: Final[str] = setting.minio.endpoint
+
+    client = Minio(endpoint=ENDPOINT, access_key=ACCESS_KEY, secret_key=SECRET_KEY, secure=False)
+
+    try:
+        client.bucket_exists("notexistbucket")
+        return True
+    except:
+        return False

--- a/backend/storage/minio_util.py
+++ b/backend/storage/minio_util.py
@@ -1,4 +1,5 @@
 from os import environ
+from traceback import format_exc
 from typing import Final
 
 from minio import Minio
@@ -17,6 +18,7 @@ def heartbeat() -> bool:
     client = Minio(endpoint=ENDPOINT, access_key=ACCESS_KEY, secret_key=SECRET_KEY, secure=False)
 
     try:
+        print(format_exc())
         client.bucket_exists("notexistbucket")
         return True
     except:

--- a/backend/storage/minio_util.py
+++ b/backend/storage/minio_util.py
@@ -18,8 +18,8 @@ def heartbeat() -> bool:
     client = Minio(endpoint=ENDPOINT, access_key=ACCESS_KEY, secret_key=SECRET_KEY, secure=False)
 
     try:
-        print(format_exc())
         client.bucket_exists("notexistbucket")
         return True
     except:
+        print(format_exc())
         return False

--- a/backend/tests/cg/conftest.py
+++ b/backend/tests/cg/conftest.py
@@ -125,8 +125,8 @@ def app():
                 }
             },
             "minio": {
-                "enable": False,
-                "endpoint": ""
+                "enable": True,
+                "endpoint": "minio:9000"
             }
         })
         _create_storage_folder(storage_path)

--- a/backend/tests/cg/conftest.py
+++ b/backend/tests/cg/conftest.py
@@ -123,6 +123,10 @@ def app():
                         "memory_limit": 131072
                     }
                 }
+            },
+            "minio": {
+                "enable": False,
+                "endpoint": ""
             }
         })
         _create_storage_folder(storage_path)

--- a/backend/tests/nocg/conftest.py
+++ b/backend/tests/nocg/conftest.py
@@ -125,8 +125,8 @@ def app():
                 }
             },
             "minio": {
-                "enable": False,
-                "endpoint": ""
+                "enable": True,
+                "endpoint": "minio:9000"
             }
         })
         _create_storage_folder(storage_path)

--- a/backend/tests/nocg/conftest.py
+++ b/backend/tests/nocg/conftest.py
@@ -123,6 +123,10 @@ def app():
                         "memory_limit": 131072
                     }
                 }
+            },
+            "minio": {
+                "enable": False,
+                "endpoint": ""
             }
         })
         _create_storage_folder(storage_path)

--- a/backend/tests/nocg/storage/test_minio_util.py
+++ b/backend/tests/nocg/storage/test_minio_util.py
@@ -1,0 +1,22 @@
+import os
+from copy import deepcopy
+from flask import Flask
+from pytest import MonkeyPatch
+
+import storage.minio_util
+from storage.minio_util import heartbeat
+
+
+class TestMinIOStorage:
+    def test_heartbeat_should_return_true(self, app: Flask):
+        with app.app_context():
+            
+            assert heartbeat()
+
+    def test_heartbeat_with_wrong_secret_should_return_false(self, app: Flask, monkeypatch: MonkeyPatch):
+        modified_environ: dict[str, str] = os.environ.copy()
+        modified_environ["MINIO_SECRET_KEY"] = "WRONG_SECRET_KEY"
+        monkeypatch.setattr(storage.minio_util, "environ", modified_environ)
+        with app.app_context():
+
+            assert not heartbeat()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,4 +21,13 @@ services:
     working_dir: /etc/nuoj-sandbox/backend
     command:
       python3 -m pytest --no-header -vv ./tests/ --cov
-  
+  minio-test:
+    image: minio/minio
+    container_name: minio
+    environment:
+      - MINIO_ROOT_USER=root
+      - MINIO_ROOT_PASSWORD=@nuoj2023
+    command: minio server /data --console-address ":9090"
+    ports:
+      - 9000:9000
+      - 9090:9090

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - NUOJ_SANDBOX_ENABLE_CG=${NUOJ_SANDBOX_ENABLE_CG}
+      - MINIO_ACCESS_KEY=root
+      - MINIO_SECRET_KEY=@nuoj2023
     privileged: true
     depends_on:
       - sandbox

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build: .
     environment:
       - NUOJ_SANDBOX_ENABLE_CG=${NUOJ_SANDBOX_ENABLE_CG}
+      - MINIO_ACCESS_KEY=root
+      - MINIO_SECRET_KEY=@nuoj2023
     tty: true
     privileged: true
     restart: always

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,9 @@ idna==3.4
 iniconfig==2.0.0
 itsdangerous==2.1.2
 Jinja2==3.1.2
+loguru==0.7.0
 MarkupSafe==2.1.2
+minio==7.1.15
 mypy==1.1.1
 mypy-extensions==1.0.0
 nodeenv==1.7.0


### PR DESCRIPTION
## What's new?

在這份 PR 中，我們將 NuOJ-Sandbox 開發了連接 MinIO 的擴充功能，讓使用者可使用 Storage 的方式來下載與暫存測資。

完成了以下的事項：
- Launch 階段時驗證 `access_key` 與 `secret_key` 是否可連結（否則 access denied）。
- 使用環境變數 `MINIO_ACCESS_KEY` 與 `MINIO_SECRET_KEY` 來傳入 `access_key` 與 `secret_key`，目前預設使用 root 來連入測試用 MinIO container。
- 設計上不考慮 MinIO 必須要在 Docker 內，它可以是任意一個可 reach 到的 MinIO。
- 可選擇是否啟用 MinIO 服務，若啟用則 storage 服務將可用。
- 完成 CI 測試，測試每次提交時 MinIO 確實可用。