### PR TITLE
完成能從 MinIO 服務下載資料

### DIFF
--- a/backend/storage/minio_util.py
+++ b/backend/storage/minio_util.py
@@ -2,20 +2,27 @@ from os import environ
 from traceback import format_exc
 from typing import Final
 
-from minio import Minio
 from flask import current_app
+from loguru import logger
+from minio import Minio
 
 from setting.util import Setting
 
 
-def heartbeat() -> bool:
+def get_client() -> Minio:
     setting: Setting = current_app.config["setting"]
-    
+
     ACCESS_KEY: Final[str] = environ.get("MINIO_ACCESS_KEY")
     SECRET_KEY: Final[str] = environ.get("MINIO_SECRET_KEY")
     ENDPOINT: Final[str] = setting.minio.endpoint
 
     client = Minio(endpoint=ENDPOINT, access_key=ACCESS_KEY, secret_key=SECRET_KEY, secure=False)
+
+    return client
+
+
+def heartbeat() -> bool:
+    client: Minio = get_client()
 
     try:
         client.bucket_exists("notexistbucket")
@@ -23,3 +30,13 @@ def heartbeat() -> bool:
     except:
         print(format_exc())
         return False
+
+
+def download(bucket_name: str, object_name: str, file_name: str) -> None:
+    assert heartbeat()
+    
+    client: Minio = get_client()
+
+    client.fget_object(bucket_name, object_name, file_name)
+
+    logger.info(f"Fetch the file {object_name} from {bucket_name}.")

--- a/backend/tests/nocg/storage/test_minio_util.py
+++ b/backend/tests/nocg/storage/test_minio_util.py
@@ -1,10 +1,59 @@
 import os
 from copy import deepcopy
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from typing import Final
+
 from flask import Flask
-from pytest import MonkeyPatch
+from minio import Minio
+from pytest import MonkeyPatch, fixture, raises
 
 import storage.minio_util
-from storage.minio_util import heartbeat
+from storage.minio_util import download, heartbeat, get_client
+
+
+BUCKET_NAME: Final[str] = "testcase"
+FILE_NAME: Final[str] = "test_file"
+FILE_STRING: Final[str] = "test_string"
+
+
+@fixture
+def storage_client(app: Flask) -> Minio:
+    with app.app_context():
+        return get_client()
+
+
+@fixture
+def place_the_file(app: Flask, storage_client: Minio) -> None:
+    _delete_the_file(app, storage_client)
+    _upload_the_file(app, storage_client)
+
+    yield
+
+    _delete_the_file(app, storage_client)
+
+
+def _upload_the_file(app: Flask, storage_client: Minio) -> None:
+    with app.app_context():
+        assert heartbeat()
+
+    if not storage_client.bucket_exists(BUCKET_NAME):
+        storage_client.make_bucket(BUCKET_NAME)
+    
+    with NamedTemporaryFile() as file:
+        file.write(FILE_STRING.encode("utf-8"))
+        file.seek(0)
+        assert file.read() == FILE_STRING.encode("utf-8")
+        storage_client.fput_object(BUCKET_NAME, FILE_NAME, file.name)
+    
+def _delete_the_file(app: Flask, storage_client: Minio) -> None:
+    with app.app_context():
+        assert heartbeat()
+
+    storage_client.remove_object(BUCKET_NAME, FILE_NAME)
+    
+    with raises(Exception):
+        storage_client.stat_object(BUCKET_NAME, FILE_NAME)
 
 
 class TestMinIOStorage:
@@ -20,3 +69,22 @@ class TestMinIOStorage:
         with app.app_context():
 
             assert not heartbeat()
+
+    def test_download_file_with_no_heart_beat_should_revert_the_action(self, app: Flask, monkeypatch: MonkeyPatch):
+        modified_environ: dict[str, str] = os.environ.copy()
+        modified_environ["MINIO_SECRET_KEY"] = "WRONG_SECRET_KEY"
+        monkeypatch.setattr(storage.minio_util, "environ", modified_environ)
+        with app.app_context():
+            with TemporaryDirectory() as temp_dir:
+
+                with raises(Exception):
+                    download(BUCKET_NAME, FILE_NAME, Path(temp_dir) / FILE_NAME)    
+
+    def test_download_file_from_storage_server_should_got_the_file(self, app: Flask, storage_client: Minio, place_the_file: None):
+        with app.app_context():
+            with TemporaryDirectory() as temp_dir:
+
+                download(BUCKET_NAME, FILE_NAME, Path(temp_dir) / FILE_NAME)
+
+                with open(Path(temp_dir) / FILE_NAME, "r") as file:
+                    assert file.read() == FILE_STRING

--- a/backend/tests/nocg/storage/test_minio_util.py
+++ b/backend/tests/nocg/storage/test_minio_util.py
@@ -45,10 +45,14 @@ def _upload_the_file(app: Flask, storage_client: Minio) -> None:
         file.seek(0)
         assert file.read() == FILE_STRING.encode("utf-8")
         storage_client.fput_object(BUCKET_NAME, FILE_NAME, file.name)
-    
+
+
 def _delete_the_file(app: Flask, storage_client: Minio) -> None:
     with app.app_context():
         assert heartbeat()
+
+    if not storage_client.bucket_exists(BUCKET_NAME):
+        return
 
     storage_client.remove_object(BUCKET_NAME, FILE_NAME)
     


### PR DESCRIPTION
完成了 MinIO 的下載服務，包含了以下的事項：

- 在 heartbeat 存在的時候才允許下載檔案（No heartbeat should revert）
- 對這個部份新增了 CI，讓下載能夠自動化，並保持在 storage 創造的檔案會在 testcase 開始與結束時清除，來讓測試環境純真。

Press ahead the issue #70