### PR TITLE
完成當接收到 storage test case 請求時從 MinIO 提取測試資料

### DIFF
--- a/backend/storage/minio_util.py
+++ b/backend/storage/minio_util.py
@@ -40,3 +40,15 @@ def download(bucket_name: str, object_name: str, file_name: str) -> None:
     client.fget_object(bucket_name, object_name, file_name)
 
     logger.info(f"Fetch the file {object_name} from {bucket_name}.")
+
+
+def is_testcase_in_storage_server(bucket_name: str, object_name: str) -> bool:
+    assert heartbeat()
+
+    client: Minio = get_client()
+
+    try:
+        client.stat_object(bucket_name, object_name)
+        return True
+    except:
+        return False

--- a/backend/tests/cg/utils/sandbox/initialize/test_util.py
+++ b/backend/tests/cg/utils/sandbox/initialize/test_util.py
@@ -5,7 +5,9 @@ import pytest
 
 from tests.nocg.utils.sandbox.initialize.test_util import (
     TestInitializeTask,
-    TestInitializeTestCase
+    TestInitializeTestCase,
+    storage_client,
+    place_the_file
 )
  
 # Since "TestCase", "TestCaseType" is start with "Test", so it will be confirm a Test Class by Pytest and raise the warning.

--- a/backend/tests/nocg/utils/sandbox/initialize/test_util.py
+++ b/backend/tests/nocg/utils/sandbox/initialize/test_util.py
@@ -1,10 +1,14 @@
+import json
 import warnings
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 import pytest
 from flask import Flask
 from freezegun import freeze_time
+from minio import Minio
 
+from storage.minio_util import heartbeat, get_client
 from utils.sandbox.enum import StatusType, TestCaseType
 from utils.sandbox.util import Task, TestCase
 from utils.isolate.util import init_sandbox
@@ -13,6 +17,57 @@ from utils.sandbox.inititalize.util import initialize_task, initialize_test_case
 # Since "TestCase", "TestCaseType" is start with "Test", so it will be confirm a Test Class by Pytest and raise the warning.
 # We need to filter the warning by warnings.filterwarnings.
 warnings.filterwarnings("ignore", message="cannot collect test class .+")
+
+BUCKET_NAME = "testcase"
+FILE_NAME = ["testcase1.json", "testcase2.json"]
+FILE_STRING = [json.dumps(["5 1 2 3 4 5", "4 1 2 3 4"]), json.dumps(["3 1 2 3", "7 1 2 3 4 5 6 7"])]
+
+
+@pytest.fixture
+def storage_client(app: Flask) -> Minio:
+    with app.app_context():
+        return get_client()
+
+
+@pytest.fixture
+def place_the_file(app: Flask, storage_client: Minio) -> None:
+    _delete_the_file(app, storage_client)
+    _upload_the_file(app, storage_client)
+
+    yield
+
+    _delete_the_file(app, storage_client)
+
+
+def _upload_the_file(app: Flask, storage_client: Minio) -> None:
+    with app.app_context():
+        assert heartbeat()
+
+    if not storage_client.bucket_exists(BUCKET_NAME):
+        storage_client.make_bucket(BUCKET_NAME)
+    
+    for index in range(len(FILE_NAME)):
+        with NamedTemporaryFile() as file:
+            file.write(FILE_STRING[index].encode("utf-8"))
+            file.seek(0)
+            assert file.read() == FILE_STRING[index].encode("utf-8")
+            storage_client.fput_object(BUCKET_NAME, FILE_NAME[index], file.name)
+
+
+def _delete_the_file(app: Flask, storage_client: Minio) -> None:
+    with app.app_context():
+        assert heartbeat()
+
+    if not storage_client.bucket_exists(BUCKET_NAME):
+        return
+
+    for index in range(len(FILE_NAME)):
+        storage_client.remove_object(BUCKET_NAME, FILE_NAME[index])
+    
+    for index in range(len(FILE_NAME)):
+        with pytest.raises(Exception):
+            storage_client.stat_object(BUCKET_NAME, FILE_NAME[index])
+
  
 class TestInitializeTask:
     def test_with_test_task_should_modify_the_state_of_task(self, app: Flask, cleanup_test_sandbox: None, test_task: Task):
@@ -93,3 +148,23 @@ class TestInitializeTestCase:
             assert Path("/var/local/lib/isolate/0/box/2.in").exists()
             assert Path("/var/local/lib/isolate/0/box/3.in").exists()
             assert Path("/var/local/lib/isolate/0/box/4.in").exists()
+
+    def test_with_fetch_file_from_storage_server_should_place_the_test_case_to_sandbox(self, app: Flask, cleanup_test_sandbox: None, test_task: Task, place_the_file: None):
+        test_task.test_case = [TestCase(TestCaseType.STATIC_FILE.value, "testcase1.json"), TestCase(TestCaseType.STATIC_FILE.value, "testcase2.json")]
+        with app.app_context():
+            init_sandbox(0)
+        
+            initialize_test_case_to_sandbox(test_task.test_case, 0)
+            
+            assert Path("/var/local/lib/isolate/0/box/1.in").exists()
+            assert Path("/var/local/lib/isolate/0/box/2.in").exists()
+            assert Path("/var/local/lib/isolate/0/box/3.in").exists()
+            assert Path("/var/local/lib/isolate/0/box/4.in").exists()
+
+    def test_with_fetch_unavailable_file_from_storage_server_should_place_the_test_case_to_sandbox(self, app: Flask, cleanup_test_sandbox: None, test_task: Task):
+        test_task.test_case = [TestCase(TestCaseType.STATIC_FILE.value, "testcase1.json"), TestCase(TestCaseType.STATIC_FILE.value, "testcase2.json")]
+        with app.app_context():
+            init_sandbox(0)
+        
+            with pytest.raises(Exception):
+                initialize_test_case_to_sandbox(test_task.test_case, 0)

--- a/backend/utils/sandbox/inititalize/util.py
+++ b/backend/utils/sandbox/inititalize/util.py
@@ -87,7 +87,7 @@ def _fetch_test_case_from_storage(filename: str) -> list[str]:
 
 
 def _prepare_testcase_to_storage_directory(filename: str) -> bool:
-    if is_file_exists(filename, TunnelCode.TESTCASE):
+    if is_file_exists(f"{filename}.json", TunnelCode.TESTCASE):
         return True
     
     setting: Setting = current_app.config["setting"]

--- a/backend/utils/sandbox/inititalize/util.py
+++ b/backend/utils/sandbox/inititalize/util.py
@@ -2,6 +2,10 @@ import json
 
 from flask import current_app
 
+from loguru import logger
+from setting.util import Setting
+from storage.util import is_file_exists, TunnelCode
+from storage.minio_util import download, is_testcase_in_storage_server
 from utils.sandbox.util import Task, TestCase, get_timestamp
 from utils.sandbox.enum import CodeType, StatusType, TestCaseType
 from utils.isolate.util import init_sandbox, touch_text_file, touch_text_file_by_file_name
@@ -62,6 +66,7 @@ def _initialize_testlib_to_sandbox(box_id: int) -> None:
 
 
 def _initialize_test_case_from_storage_and_return_last_index(filename: str, start_index: int, box_id: int) -> int:
+    assert _prepare_testcase_to_storage_directory(filename)
     test_case_list: list[str] = _fetch_test_case_from_storage(filename)
     for i in range(len(test_case_list)):
         touch_text_file_by_file_name(test_case_list[i], f"{i + start_index}.in", box_id)
@@ -79,3 +84,16 @@ def _fetch_test_case_from_storage(filename: str) -> list[str]:
     with open(f"{storage_path}/testcase/{filename}.json", "r") as f:
         json_object = json.loads(f.read())
     return json_object
+
+
+def _prepare_testcase_to_storage_directory(filename: str) -> bool:
+    if is_file_exists(filename, TunnelCode.TESTCASE):
+        return True
+    
+    setting: Setting = current_app.config["setting"]
+    if setting.minio.enable and is_testcase_in_storage_server("testcase", filename):
+        storage_path: str = current_app.config["STORAGE_PATH"]
+        download("testcase", filename, f"{storage_path}/testcase/{filename}.json")
+        return True
+    
+    return False


### PR DESCRIPTION
## What's new?

完成了處理 Storage 請求的服務，包含了以下的事項：

- 準備測試資料的部份，採取 Trying 策略，僅用方法嘗試取得測資。
- 如果 container 有檔案，就不會從 storage server 進行提取。
- 如果 container 沒有檔案，且 MinIO 是 enabled 的，就會從 storage server 嘗試進行提取。
- 如果 container 沒有檔案，且無法從 MinIO 中提取，那就會發生 assert exception，中止 task 的運行。
- 對這個部份新增了 CI 測試。

額外手動整合測試了一下：

- 目前有一個小 bug 是 judge 的情況時會誤估測試的數量，這個部份待修正。