### PR TITLE
修復 `threading` 為 `fasle` 時格式錯誤的問題

### DIFF
--- a/backend/api/judge/route.py
+++ b/backend/api/judge/route.py
@@ -34,6 +34,6 @@ def judge_route():
     response = {"status": "OK", "type": execution_type, "tracker_id": tracker_id}
 
     if not option["threading"]:
-        response["result"] = result
+        response["data"] = result
 
     return Response(json.dumps(response), mimetype="application/json")

--- a/backend/tests/nocg/api/judge/test_route.py
+++ b/backend/tests/nocg/api/judge/test_route.py
@@ -43,11 +43,118 @@ def payload(user_code: str, checker_code: str) -> dict[str, Any]:
         }
     }
 
+
+def replace_time_and_memory_attribute(payload: dict[str, Any]) -> dict[str, Any]:
+    payload["tracker_id"] = "03e8a7f6-46b2-4195-9791-39f4f21cc96b"
+    if "data" in payload:
+        payload["data"]["compile_detail"]["solution"]["time"] = "0"
+        payload["data"]["compile_detail"]["solution"]["memory"] = "0"
+        payload["data"]["compile_detail"]["checker"]["time"] = "0"
+        payload["data"]["compile_detail"]["checker"]["memory"] = "0"
+        payload["data"]["compile_detail"]["submit"]["time"] = "0"
+        payload["data"]["compile_detail"]["submit"]["memory"] = "0"
+
+        for i in range(len(payload["data"]["judge_detail"])):
+            payload["data"]["judge_detail"][i]["runtime_info"]["solution"]["time"] = "0"
+            payload["data"]["judge_detail"][i]["runtime_info"]["solution"]["memory"] = "0"
+            payload["data"]["judge_detail"][i]["runtime_info"]["submit"]["time"] = "0"
+            payload["data"]["judge_detail"][i]["runtime_info"]["submit"]["memory"] = "0"
+            payload["data"]["judge_detail"][i]["runtime_info"]["checker"]["time"] = "0"
+            payload["data"]["judge_detail"][i]["runtime_info"]["checker"]["memory"] = "0"
+
+    return payload
+
+
 class TestSubmit:
     def test_submit_code_with_no_threading_should_respond_http_status_code_ok(self, client: FlaskClient, payload: dict[str, Any]):
         response: TestResponse = client.post("/api/judge", json=payload)
 
         assert response.status_code == HTTPStatus.OK
+
+    def test_submit_code_with_no_threading_should_respond_correct_payload(self, client: FlaskClient, payload: dict[str, Any]):
+        expected_payload: dict[str, Any] = {
+            "status": "OK",
+            "tracker_id": "03e8a7f6-46b2-4195-9791-39f4f21cc96b",
+            "type": "Judge",
+            "data": {
+                "status": "AC",
+                "message": "OK.",
+                "compile_detail": {
+                    "solution": {
+                        "time": "1.188",
+                        "memory": "156816",
+                        "exitcode": "0"
+                    },
+                    "checker": {
+                        "time": "1.717",
+                        "memory": "158192",
+                        "exitcode": "0"
+                    },
+                    "submit": {
+                        "time": "1.012",
+                        "memory": "156920",
+                        "exitcode": "0"
+                    }
+                },
+                "judge_detail": [
+                    {
+                        "verdict": "AC",
+                        "output_set": {
+                            "submit": "5",
+                            "answer": "5"
+                        },
+                        "runtime_info": {
+                            "solution": {
+                                "time": "0.002",
+                                "memory": "3656",
+                                "exitcode": "0"
+                            },
+                            "submit": {
+                                "time": "0.002",
+                                "memory": "3560",
+                                "exitcode": "0"
+                            },
+                            "checker": {
+                                "time": "0.002",
+                                "memory": "3884",
+                                "exitcode": "0"
+                            }
+                        },
+                        "log": "ok single line: '5'\n"
+                    },
+                    {
+                        "verdict": "AC",
+                        "output_set": {
+                            "submit": "7",
+                            "answer": "7"
+                        },
+                        "runtime_info": {
+                            "solution": {
+                                "time": "0.002",
+                                "memory": "3628",
+                                "exitcode": "0"
+                            },
+                            "submit": {
+                                "time": "0.002",
+                                "memory": "3656",
+                                "exitcode": "0"
+                            },
+                            "checker": {
+                                "time": "0.003",
+                                "memory": "3832",
+                                "exitcode": "0"
+                            }
+                        },
+                        "log": "ok single line: '7'\n"
+                    }
+                ]
+            }
+        }
+        response: TestResponse = client.post("/api/judge", json=payload)
+
+        assert response.status_code == HTTPStatus.OK
+        json: dict[str, Any] = response.get_json(silent=True)
+        assert replace_time_and_memory_attribute(json) == replace_time_and_memory_attribute(expected_payload)
 
     def test_submit_code_with_threading_should_respond_http_status_code_ok(self, client: FlaskClient, payload: dict[str, Any]):
         payload["options"]["threading"] = True

--- a/backend/tests/nocg/api/judge/test_route.py
+++ b/backend/tests/nocg/api/judge/test_route.py
@@ -174,7 +174,7 @@ class TestSubmit:
         response: TestResponse = client.post("/api/judge", json=payload)
         
         assert response.status_code == HTTPStatus.OK
-        assert response.json["result"]["judge_detail"][0]["verdict"] == "AC"  
+        assert response.json["data"]["judge_detail"][0]["verdict"] == "AC"  
         out, _ = capfd.readouterr()
         assert "send successfully" in out.split("\n")[-2]
 
@@ -185,7 +185,7 @@ class TestSubmit:
         response: TestResponse = client.post("/api/judge", json=payload)
         
         assert response.status_code == HTTPStatus.OK
-        assert response.json["result"]["compile_detail"]["submit"]["exitcode"] == "1"  
+        assert response.json["data"]["compile_detail"]["submit"]["exitcode"] == "1"  
         out, _ = capfd.readouterr()
         assert "has error that occur result" in out.split("\n")[-2]
 


### PR DESCRIPTION
## What's new?

在這份 PR 中，我修復 `threading` 為 `fasle` 時發生格式錯誤的問題，並將 `result` 欄位重新命名成 `data`。