### PR TITLE
修復 cleanup 函數未被 semaphore 保護而造成 race condition 的問題

### DIFF
--- a/backend/api/judge/util.py
+++ b/backend/api/judge/util.py
@@ -70,8 +70,8 @@ def execute_task_with_specific_tracker_id(tracker_id):
 
     # Free thread with release function.
     available_box.add(box_id)
-    semaphores.release()
     cleanup_sandbox(box_id)
+    semaphores.release()
     return task.result
 
 
@@ -98,6 +98,7 @@ def _send_webhook_with_webhook_url(task: Task, tracker_id: int):
             task.options.webhook_url,
             data=json.dumps({"status": "OK", "data": task.result}),
             headers={"content-type": "application/json"},
+            timeout=10
         )
         if resp.status_code != 200:
             print(f"webhook_url {task.options.webhook_url} has error that occur result {tracker_id} has error.")

--- a/backend/api/judge/util.py
+++ b/backend/api/judge/util.py
@@ -98,7 +98,6 @@ def _send_webhook_with_webhook_url(task: Task, tracker_id: int):
             task.options.webhook_url,
             data=json.dumps({"status": "OK", "data": task.result}),
             headers={"content-type": "application/json"},
-            timeout=10
         )
         if resp.status_code != 200:
             print(f"webhook_url {task.options.webhook_url} has error that occur result {tracker_id} has error.")


### PR DESCRIPTION
## What's new?

在這份 PR 中，我修復了 cleanup 函數未被 semaphore 保護而造成 race condition 的問題。

在經過 @royis87 的壓力測試後，發現在遇到沙盒的任務崩潰後，整個沙盒會跟著一起崩潰。
經查，主要是因為沙盒清理的函數並未被 semaphore 保護，導致下一個任務在沙盒未清理完時注入，導致出現災難。